### PR TITLE
sensate-iot: update the gateway URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.0] - 06-06-2021
+## [1.0.2] - 06-06-2021
+
+### Updated
+
+- Updated the Sensate IoT Gateway API URI
+
+## [1.0.1] - 06-06-2021
 
 ### Updated
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Sensate IoT Smart Energy project implements an IoT solution for (Dutch)
 Smart Meters. The project consists of several repository's:
 
 - DSMR parser;
-- DSMR web client (implementator of this service);
+- DSMR web client;
 - Several customer facing apps;
 - DSMR firmware (this repo).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,8 @@ be answered, and issues/bug reports will be instantly closed.
 
 | Version   | Supported          |
 | --------- | ------------------ |
-| <= 1.0.x  | :x:                |
+| 1.0.x     | :white_check_mark: |
+| < 1.0.0   | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/lib/sensateiot/sensateiotclient.cpp
+++ b/lib/sensateiot/sensateiotclient.cpp
@@ -16,7 +16,7 @@
 #define DBG_STREAM(...)
 #endif
 
-static String url = "https://api.sensateiot.com/network/v1/gateway/messages";
+static String url = "https://api.sensateiot.com/gateway/v1/messages";
 static X509List certChain(rootCa);
 
 namespace sensateiot


### PR DESCRIPTION
Update the URI of the Sensate IoT Gateway API. The URI has changed from https://api.sensateiot.com/network/v1/gateway/messages to https://api.sensateiot.com/gateway/v1/messages.